### PR TITLE
19 header file do not check fully

### DIFF
--- a/script/build-pack-win32.cmd
+++ b/script/build-pack-win32.cmd
@@ -1,6 +1,6 @@
 @ECHO OFF
 
-IF EXIST release (RD release)
+IF EXIST release (RD /S /Q release)
 python cppnamelint.py bldgpack .. .\release
 
 ECHO.

--- a/script/cppnamelint.py
+++ b/script/cppnamelint.py
@@ -259,7 +259,7 @@ def convert_py_args_to_exe_args(py_args) -> str:
 def find_sample_files(start_dir: str) -> []:
     paired_list = []
 
-    include_src_files: [] = ['.c', '.cpp']
+    include_src_files: [] = ['.c', '.cpp', '.h']
     include_cfg_files: [] = ['.toml']
 
     file_obj = File()

--- a/source/LearnIt.cpp
+++ b/source/LearnIt.cpp
@@ -13,11 +13,8 @@ bool LearnIt::PrintDecl(Decl *pDecl) {
   }
   // clang-format off
 
+    DcLib::Log::Out(INFO_ALL, "");
 	DcLib::Log::Out(INFO_ALL, "v--start line--------------------------------------------------------------------v");
-	if (isa<NamedDecl>(pDecl))
-	{
-		_PrintNamedDecl(dyn_cast<NamedDecl> (pDecl));
-	}
 
 	if (isa<RecordDecl>(pDecl))
 	{
@@ -49,7 +46,18 @@ bool LearnIt::PrintDecl(Decl *pDecl) {
 		_PrintParmVarDecl(dyn_cast<ParmVarDecl> (pDecl));
 	}
 
-	DcLib::Log::Out(INFO_ALL, "v--end line-----------------------------------------------------------------------v");
+    if (isa<TypedefDecl>(pDecl))
+    {
+        _PrintTypedefDecl(dyn_cast<TypedefDecl> (pDecl));
+    }
+
+    // Keep this as the last.
+    if (isa<NamedDecl>(pDecl))
+    {
+        _PrintNamedDecl(dyn_cast<NamedDecl> (pDecl));
+    }
+
+	DcLib::Log::Out(INFO_ALL, "^--end line-----------------------------------------------------------------------^");
   // clang-format on
 
   return true;
@@ -57,251 +65,125 @@ bool LearnIt::PrintDecl(Decl *pDecl) {
 
 void LearnIt::_PrintNamedDecl(NamedDecl *pDecl) {
 
+  // clang-format off
   DcLib::Log::Out(INFO_ALL, "NamedDecl");
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.getName()                                = %s",
-                  pDecl->getName().str().c_str());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.getNameAsString()                        = %s",
-                  pDecl->getNameAsString().c_str());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.getDeclName()                            = %s",
-                  pDecl->getDeclName().getAsString().c_str());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.getDeclKindName()                        = %s",
-                  pDecl->getDeclKindName());
-  ;
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.getQualifiedNameAsString()               = %s",
-                  pDecl->getQualifiedNameAsString().c_str());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isCanonicalDecl()                        = %d",
-                  pDecl->isCanonicalDecl());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isCXXClassMember()                       = %d",
-                  pDecl->isCXXClassMember());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isCXXInstanceMember()                    = %d",
-                  pDecl->isCXXInstanceMember());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isDefinedOutsideFunctionOrMethod()       = %d",
-                  pDecl->isDefinedOutsideFunctionOrMethod());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isDeprecated()                           = %d",
-                  pDecl->isDeprecated());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isExported()                             = %d",
-                  pDecl->isExported());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isExternallyDeclarable()                 = %d",
-                  pDecl->isExternallyDeclarable());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isExternallyVisible()                    = %d",
-                  pDecl->isExternallyVisible());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isFirstDecl()                            = %d",
-                  pDecl->isFirstDecl());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isFromASTFile()                          = %d",
-                  pDecl->isFromASTFile());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isFunctionOrFunctionTemplate()           = %d",
-                  pDecl->isFunctionOrFunctionTemplate());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isHidden()                               = %d",
-                  pDecl->isHidden());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isImplicit()                             = %d",
-                  pDecl->isImplicit());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isInAnonymousNamespace()                 = %d",
-                  pDecl->isInAnonymousNamespace());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isInStdNamespace()                       = %d",
-                  pDecl->isInStdNamespace());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isInvalidDecl()                          = %d",
-                  pDecl->isInvalidDecl());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isLexicallyWithinFunctionOrMethod()      = %d",
-                  pDecl->isLexicallyWithinFunctionOrMethod());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isLinkageValid()                         = %d",
-                  pDecl->isLinkageValid());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isLocalExternDecl()                      = %d",
-                  pDecl->isLocalExternDecl());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isModulePrivate()                        = %d",
-                  pDecl->isModulePrivate());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isOutOfLine()                            = %d",
-                  pDecl->isOutOfLine());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isParameterPack()                        = %d",
-                  pDecl->isParameterPack());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isReferenced()                           = %d",
-                  pDecl->isReferenced());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isTemplated()                            = %d",
-                  pDecl->isTemplated());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isTemplateDecl()                         = %d",
-                  pDecl->isTemplateDecl());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isTemplateParameter()                    = %d",
-                  pDecl->isTemplateParameter());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isTemplateParameterPack()                = %d",
-                  pDecl->isTemplateParameterPack());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isThisDeclarationReferenced()            = %d",
-                  pDecl->isThisDeclarationReferenced());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isTopLevelDeclInObjCContainer()          = %d",
-                  pDecl->isTopLevelDeclInObjCContainer());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isUnavailable()                          = %d",
-                  pDecl->isUnavailable());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isUsed()                                 = %d",
-                  pDecl->isUsed());
-  DcLib::Log::Out(INFO_ALL,
-                  "Decl.isWeakImported()                         = %d",
-                  pDecl->isWeakImported());
+  DcLib::Log::Out(INFO_ALL, "Decl.getName()                                = %s", pDecl->getName().str().c_str());
+  DcLib::Log::Out(INFO_ALL, "Decl.getNameAsString()                        = %s", pDecl->getNameAsString().c_str());
+  DcLib::Log::Out(INFO_ALL, "Decl.getDeclName()                            = %s", pDecl->getDeclName().getAsString().c_str());
+  DcLib::Log::Out(INFO_ALL, "Decl.getDeclKindName()                        = %s", pDecl->getDeclKindName());
+  DcLib::Log::Out(INFO_ALL, "Decl.getQualifiedNameAsString()               = %s", pDecl->getQualifiedNameAsString().c_str());
+  DcLib::Log::Out(INFO_ALL, "Decl.isCanonicalDecl()                        = %d", pDecl->isCanonicalDecl());
+  DcLib::Log::Out(INFO_ALL, "Decl.isCXXClassMember()                       = %d", pDecl->isCXXClassMember());
+  DcLib::Log::Out(INFO_ALL, "Decl.isCXXInstanceMember()                    = %d", pDecl->isCXXInstanceMember());
+  DcLib::Log::Out(INFO_ALL, "Decl.isDefinedOutsideFunctionOrMethod()       = %d", pDecl->isDefinedOutsideFunctionOrMethod());
+  DcLib::Log::Out(INFO_ALL, "Decl.isDeprecated()                           = %d", pDecl->isDeprecated());
+  DcLib::Log::Out(INFO_ALL, "Decl.isExported()                             = %d", pDecl->isExported());
+  DcLib::Log::Out(INFO_ALL, "Decl.isExternallyDeclarable()                 = %d", pDecl->isExternallyDeclarable());
+  DcLib::Log::Out(INFO_ALL, "Decl.isExternallyVisible()                    = %d", pDecl->isExternallyVisible());
+  DcLib::Log::Out(INFO_ALL, "Decl.isFirstDecl()                            = %d", pDecl->isFirstDecl());
+  DcLib::Log::Out(INFO_ALL, "Decl.isFromASTFile()                          = %d", pDecl->isFromASTFile());
+  DcLib::Log::Out(INFO_ALL, "Decl.isFunctionOrFunctionTemplate()           = %d", pDecl->isFunctionOrFunctionTemplate());
+  DcLib::Log::Out(INFO_ALL, "Decl.isHidden()                               = %d", pDecl->isHidden());
+  DcLib::Log::Out(INFO_ALL, "Decl.isImplicit()                             = %d", pDecl->isImplicit());
+  DcLib::Log::Out(INFO_ALL, "Decl.isInAnonymousNamespace()                 = %d", pDecl->isInAnonymousNamespace());
+  DcLib::Log::Out(INFO_ALL, "Decl.isInStdNamespace()                       = %d", pDecl->isInStdNamespace());
+  DcLib::Log::Out(INFO_ALL, "Decl.isInvalidDecl()                          = %d", pDecl->isInvalidDecl());
+  DcLib::Log::Out(INFO_ALL, "Decl.isLexicallyWithinFunctionOrMethod()      = %d", pDecl->isLexicallyWithinFunctionOrMethod());
+  DcLib::Log::Out(INFO_ALL, "Decl.isLinkageValid()                         = %d", pDecl->isLinkageValid());
+  DcLib::Log::Out(INFO_ALL, "Decl.isLocalExternDecl()                      = %d", pDecl->isLocalExternDecl());
+  DcLib::Log::Out(INFO_ALL, "Decl.isModulePrivate()                        = %d", pDecl->isModulePrivate());
+  DcLib::Log::Out(INFO_ALL, "Decl.isOutOfLine()                            = %d", pDecl->isOutOfLine());
+  DcLib::Log::Out(INFO_ALL, "Decl.isParameterPack()                        = %d", pDecl->isParameterPack());
+  DcLib::Log::Out(INFO_ALL, "Decl.isReferenced()                           = %d", pDecl->isReferenced());
+  DcLib::Log::Out(INFO_ALL, "Decl.isTemplated()                            = %d", pDecl->isTemplated());
+  DcLib::Log::Out(INFO_ALL, "Decl.isTemplateDecl()                         = %d", pDecl->isTemplateDecl());
+  DcLib::Log::Out(INFO_ALL, "Decl.isTemplateParameter()                    = %d", pDecl->isTemplateParameter());
+  DcLib::Log::Out(INFO_ALL, "Decl.isTemplateParameterPack()                = %d", pDecl->isTemplateParameterPack());
+  DcLib::Log::Out(INFO_ALL, "Decl.isThisDeclarationReferenced()            = %d", pDecl->isThisDeclarationReferenced());
+  DcLib::Log::Out(INFO_ALL, "Decl.isTopLevelDeclInObjCContainer()          = %d", pDecl->isTopLevelDeclInObjCContainer());
+  DcLib::Log::Out(INFO_ALL, "Decl.isUnavailable()                          = %d", pDecl->isUnavailable());
+  DcLib::Log::Out(INFO_ALL, "Decl.isUsed()                                 = %d", pDecl->isUsed());
+  DcLib::Log::Out(INFO_ALL, "Decl.isWeakImported()                         = %d", pDecl->isWeakImported());
+  // clang-format on
 }
 
 void LearnIt::_PrintValueDecl(ValueDecl *pDecl) {
-
+  // clang-format off
   DcLib::Log::Out(INFO_ALL, "ValueDecl");
-  DcLib::Log::Out(INFO_ALL,
-                  "ValueDecl.isWeak()                            = %d",
-                  pDecl->isWeak());
+  DcLib::Log::Out(INFO_ALL, "ValueDecl.isWeak()                            = %d", pDecl->isWeak());
+  // clang-format on
 }
 
 void LearnIt::_PrintFieldDecl(FieldDecl *pDecl) {
-
+  // clang-format off
   DcLib::Log::Out(INFO_ALL, "FieldDecl");
-  DcLib::Log::Out(INFO_ALL,
-                  "FieldDecl.isBitField()                        = %d",
-                  pDecl->isBitField());
-  DcLib::Log::Out(INFO_ALL,
-                  "FieldDecl.isAnonymousStructOrUnion()          = %d",
-                  pDecl->isAnonymousStructOrUnion());
+  DcLib::Log::Out(INFO_ALL, "FieldDecl.isBitField()                        = %d", pDecl->isBitField());
+  DcLib::Log::Out(INFO_ALL, "FieldDecl.isAnonymousStructOrUnion()          = %d", pDecl->isAnonymousStructOrUnion());
+  // clang-format on
 }
 
 void LearnIt::_PrintVarDecl(VarDecl *pDecl) {
-
+  // clang-format off
   DcLib::Log::Out(INFO_ALL, "VarDecl");
-  DcLib::Log::Out(INFO_ALL,
-                  "VarDecl.isExternC()                           = %d",
-                  pDecl->isExternC());
-  DcLib::Log::Out(INFO_ALL,
-                  "VarDecl.isInExternCContext()                  = %d",
-                  pDecl->isInExternCContext());
-  DcLib::Log::Out(INFO_ALL,
-                  "VarDecl.isInExternCXXContext()                = %d",
-                  pDecl->isInExternCXXContext());
-  DcLib::Log::Out(INFO_ALL,
-                  "VarDecl.isLocalVarDecl()                      = %d",
-                  pDecl->isLocalVarDecl());
-  DcLib::Log::Out(INFO_ALL,
-                  "VarDecl.isLocalVarDeclOrParm()                = %d",
-                  pDecl->isLocalVarDeclOrParm());
-  DcLib::Log::Out(INFO_ALL,
-                  "VarDecl.isFunctionOrMethodVarDecl()           = %d",
-                  pDecl->isFunctionOrMethodVarDecl());
-  DcLib::Log::Out(INFO_ALL,
-                  "VarDecl.isStaticDataMember()                  = %d",
-                  pDecl->isStaticDataMember());
-  DcLib::Log::Out(INFO_ALL,
-                  "VarDecl.isFileVarDecl()                       = %d",
-                  pDecl->isFileVarDecl());
-  DcLib::Log::Out(INFO_ALL,
-                  "VarDecl.hasInit()                             = %d",
-                  pDecl->hasInit());
+  DcLib::Log::Out(INFO_ALL, "VarDecl.isExternC()                           = %d", pDecl->isExternC());
+  DcLib::Log::Out(INFO_ALL, "VarDecl.isInExternCContext()                  = %d", pDecl->isInExternCContext());
+  DcLib::Log::Out(INFO_ALL, "VarDecl.isInExternCXXContext()                = %d", pDecl->isInExternCXXContext());
+  DcLib::Log::Out(INFO_ALL, "VarDecl.isLocalVarDecl()                      = %d", pDecl->isLocalVarDecl());
+  DcLib::Log::Out(INFO_ALL, "VarDecl.isLocalVarDeclOrParm()                = %d", pDecl->isLocalVarDeclOrParm());
+  DcLib::Log::Out(INFO_ALL, "VarDecl.isFunctionOrMethodVarDecl()           = %d", pDecl->isFunctionOrMethodVarDecl());
+  DcLib::Log::Out(INFO_ALL, "VarDecl.isStaticDataMember()                  = %d", pDecl->isStaticDataMember());
+  DcLib::Log::Out(INFO_ALL, "VarDecl.isFileVarDecl()                       = %d", pDecl->isFileVarDecl());
+  DcLib::Log::Out(INFO_ALL, "VarDecl.hasInit()                             = %d", pDecl->hasInit());
+  // clang-format on
 }
 
 void LearnIt::_PrintFunctionDecl(FunctionDecl *pDecl) {
-
+  // clang-format off
   DcLib::Log::Out(INFO_ALL, "FunctionDecl");
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.getNameInfo()                    = %s",
-                  pDecl->getNameInfo().getAsString().c_str());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isDefined()                      = %d",
-                  pDecl->isDefined());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isThisDeclarationADefinition()   = %d",
-                  pDecl->isThisDeclarationADefinition());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.doesThisDeclarationHaveABody()   = %d",
-                  pDecl->doesThisDeclarationHaveABody());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isVariadic()                     = %d",
-                  pDecl->isVariadic());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isVirtualAsWritten()             = %d",
-                  pDecl->isVirtualAsWritten());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isPure()                         = %d",
-                  pDecl->isPure());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isDefaulted()                    = %d",
-                  pDecl->isDefaulted());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.hasPrototype()                   = %d",
-                  pDecl->hasPrototype());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isMain()                         = %d",
-                  pDecl->isMain());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isExternC()                      = %d",
-                  pDecl->isExternC());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isInExternCContext()             = %d",
-                  pDecl->isInExternCContext());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isInExternCXXContext()           = %d",
-                  pDecl->isInExternCXXContext());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isGlobal()                       = %d",
-                  pDecl->isGlobal());
-  DcLib::Log::Out(INFO_ALL,
-                  "FunctionDecl.isInlined()                      = %d",
-                  pDecl->isInlined());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.getNameInfo()                    = %s", pDecl->getNameInfo().getAsString().c_str());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isDefined()                      = %d", pDecl->isDefined());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isThisDeclarationADefinition()   = %d", pDecl->isThisDeclarationADefinition());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.doesThisDeclarationHaveABody()   = %d", pDecl->doesThisDeclarationHaveABody());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isVariadic()                     = %d", pDecl->isVariadic());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isVirtualAsWritten()             = %d", pDecl->isVirtualAsWritten());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isPure()                         = %d", pDecl->isPure());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isDefaulted()                    = %d", pDecl->isDefaulted());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.hasPrototype()                   = %d", pDecl->hasPrototype());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isMain()                         = %d", pDecl->isMain());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isExternC()                      = %d", pDecl->isExternC());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isInExternCContext()             = %d", pDecl->isInExternCContext());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isInExternCXXContext()           = %d", pDecl->isInExternCXXContext());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isGlobal()                       = %d", pDecl->isGlobal());
+  DcLib::Log::Out(INFO_ALL, "FunctionDecl.isInlined()                      = %d", pDecl->isInlined());
+  // clang-format on
 }
 
 void LearnIt::_PrintParmVarDecl(ParmVarDecl *pDecl) {
-
+  // clang-format off
   DcLib::Log::Out(INFO_ALL, "ParmVarDecl");
-  DcLib::Log::Out(INFO_ALL, "ParmVarDecl.isObjCMethodParameter()          = %d",
-                  pDecl->isObjCMethodParameter());
-  DcLib::Log::Out(INFO_ALL, "ParmVarDecl.hasDefaultArg()                  = %d",
-                  pDecl->hasDefaultArg());
-  DcLib::Log::Out(INFO_ALL, "ParmVarDecl.hasUnparsedDefaultArg()          = %d",
-                  pDecl->hasUnparsedDefaultArg());
-  DcLib::Log::Out(INFO_ALL, "ParmVarDecl.hasInheritedDefaultArg()         = %d",
-                  pDecl->hasInheritedDefaultArg());
+  DcLib::Log::Out(INFO_ALL, "ParmVarDecl.isObjCMethodParameter()          = %d", pDecl->isObjCMethodParameter());
+  DcLib::Log::Out(INFO_ALL, "ParmVarDecl.hasDefaultArg()                  = %d", pDecl->hasDefaultArg());
+  DcLib::Log::Out(INFO_ALL, "ParmVarDecl.hasUnparsedDefaultArg()          = %d", pDecl->hasUnparsedDefaultArg());
+  DcLib::Log::Out(INFO_ALL, "ParmVarDecl.hasInheritedDefaultArg()         = %d", pDecl->hasInheritedDefaultArg());
+  // clang-format on
 }
 
 void LearnIt::_PrintRecordDecl(RecordDecl *pDecl) {
-
+  // clang-format off
   DcLib::Log::Out(INFO_ALL, "RecordDecl");
-  DcLib::Log::Out(INFO_ALL,
-                  "RecordDecl.hasFlexibleArrayMember()           = %d",
-                  pDecl->hasFlexibleArrayMember());
-  DcLib::Log::Out(INFO_ALL,
-                  "RecordDecl.isAnonymousStructOrUnion()         = %d",
-                  pDecl->isAnonymousStructOrUnion());
-  DcLib::Log::Out(INFO_ALL,
-                  "RecordDecl.hasObjectMember()                  = %d",
-                  pDecl->hasObjectMember());
-  DcLib::Log::Out(INFO_ALL,
-                  "RecordDecl.hasVolatileMember()                = %d",
-                  pDecl->hasVolatileMember());
-  DcLib::Log::Out(INFO_ALL,
-                  "RecordDecl.isLambda()                         = %d",
-                  pDecl->isLambda());
+  DcLib::Log::Out(INFO_ALL, "RecordDecl.hasFlexibleArrayMember()           = %d", pDecl->hasFlexibleArrayMember());
+  DcLib::Log::Out(INFO_ALL, "RecordDecl.isAnonymousStructOrUnion()         = %d", pDecl->isAnonymousStructOrUnion());
+  DcLib::Log::Out(INFO_ALL, "RecordDecl.hasObjectMember()                  = %d", pDecl->hasObjectMember());
+  DcLib::Log::Out(INFO_ALL, "RecordDecl.hasVolatileMember()                = %d", pDecl->hasVolatileMember());
+  DcLib::Log::Out(INFO_ALL, "RecordDecl.isLambda()                         = %d", pDecl->isLambda());
+  // clang-format on
+}
+
+void LearnIt::_PrintTypedefDecl(TypedefDecl *pDecl) {
+  // clang-format of
+  DcLib::Log::Out(INFO_ALL, "TypedefDecl");
+  // TypedefDecl
+  // static bool classof(const Decl *D) { return classofKind(D->getKind()); }
+  // static bool classofKind(Kind K) { return K == Typedef; }
+  // clang-format on
 }

--- a/source/LearnIt.h
+++ b/source/LearnIt.h
@@ -34,6 +34,7 @@ private:
   void _PrintFunctionDecl(FunctionDecl *pDecl);
   void _PrintParmVarDecl(ParmVarDecl *pDecl);
   void _PrintRecordDecl(RecordDecl *pDecl);
+  void _PrintTypedefDecl(TypedefDecl *pDecl);
 };
 
 #endif // __LEARN_IT_H__

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -74,14 +74,15 @@ int RunCheck(namelint::MemoBoard &Memo) {
   //
   // Create clang tool then add clang tool arguments.
   //
-  vector<string> SingleFileInList = { Memo.File.Source };
+  vector<string> SingleFileInList = {Memo.File.Source};
   ClangTool Tool(*Compilations, SingleFileInList);
   // Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster("--I./",
   // ArgumentInsertPosition::BEGIN));
   Tool.appendArgumentsAdjuster(
       getInsertArgumentAdjuster("-v", ArgumentInsertPosition::BEGIN));
   Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(
-      "--language=c++", ArgumentInsertPosition::BEGIN)); // Make it parses header file.
+      "--language=c++",
+      ArgumentInsertPosition::BEGIN)); // Make it parses header file.
 
   Tool.setDiagnosticConsumer(new IgnoringDiagConsumer());
 

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -47,18 +47,18 @@ int RunCheck(namelint::MemoBoard &Memo) {
   DcLib::Log::Out(INFO_ALL, "Config File = %s", Memo.File.Config.c_str());
   DcLib::Log::Out(INFO_ALL, "OutputJson  = %s", OutputJson.c_str());
 
-  if (!llvm::sys::fs::exists(CheckInputSrc)) {
+  if (!llvm::sys::fs::exists(Memo.File.Source)) {
     cout << "Error: Failed to find input source file." << endl;
     return 1;
   }
 
-  if (!llvm::sys::fs::exists(CheckInputConfig)) {
+  if (!llvm::sys::fs::exists(Memo.File.Config)) {
     cout << "Error: Failed to find config file." << endl;
     return 2;
   }
 
   string errorReason;
-  if (!Memo.Config.LoadFile(CheckInputSrc, errorReason)) {
+  if (!Memo.Config.LoadFile(Memo.File.Config, errorReason)) {
     cout << "Error: Failed to load config file (format wrong)." << endl;
     cout << errorReason << endl;
     return 3;
@@ -78,8 +78,8 @@ int RunCheck(namelint::MemoBoard &Memo) {
   ClangTool Tool(*Compilations, SingleFileInList);
   // Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster("--I./",
   // ArgumentInsertPosition::BEGIN));
-  Tool.appendArgumentsAdjuster(
-      getInsertArgumentAdjuster("-v", ArgumentInsertPosition::BEGIN));
+  // Tool.appendArgumentsAdjuster(
+  //    getInsertArgumentAdjuster("-v", ArgumentInsertPosition::BEGIN));
   Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(
       "--language=c++",
       ArgumentInsertPosition::BEGIN)); // Make it parses header file.
@@ -209,8 +209,10 @@ bool PrintTraceMemo(const MemoBoard &MemoBoard) {
   bool bStatus = true;
   char szText[512] = {0};
 
-  cout << " File    = " << MemoBoard.File.Source << endl;
-  cout << " Config  = " << MemoBoard.File.Config << endl;
+  cout << " File    = "
+       << llvm::sys::path::filename(MemoBoard.File.Source).data() << endl;
+  cout << " Config  = "
+       << llvm::sys::path::filename(MemoBoard.File.Config).data() << endl;
   for (size_t nIdx = 0; nIdx < MemoBoard.Dir.Includes.size(); nIdx++) {
     sprintf(szText, " Inc[%2d] = %s", nIdx + 1,
             MemoBoard.Dir.Includes[nIdx].c_str());

--- a/source/MyAstVisitor.cpp
+++ b/source/MyAstVisitor.cpp
@@ -421,3 +421,12 @@ bool MyASTVisitor::VisitParmVarDecl(ParmVarDecl *pDecl) {
 
   return true;
 }
+
+bool MyASTVisitor::VisitTypedefDecl(TypedefDecl *pDecl) {
+  APP_CONTEXT *pAppCxt = ((APP_CONTEXT *)GetAppCxt());
+
+  if (pAppCxt->MemoBoard.Option.bEnableLog) {
+    this->m_LearnIt.PrintDecl(pDecl);
+  }
+  return true;
+}

--- a/source/MyAstVisitor.h
+++ b/source/MyAstVisitor.h
@@ -75,6 +75,76 @@ public:
   bool VisitFieldDecl(FieldDecl *pDecl);
   bool VisitReturnStmt(ReturnStmt *pRetStmt);
   bool VisitParmVarDecl(ParmVarDecl *pDecl);
+  bool VisitTypedefDecl(TypedefDecl *pDecl);
 };
+
+/*
+  // Declaration visitors
+  bool VisitTypeAliasTemplateDecl(TypeAliasTemplateDecl *D);
+  bool VisitTypeAliasDecl(TypeAliasDecl *D);
+  bool VisitAttributes(Decl *D);
+  bool VisitBlockDecl(BlockDecl *B);
+  bool VisitCXXRecordDecl(CXXRecordDecl *D);
+  Optional<bool> shouldVisitCursor(CXCursor C);
+  bool VisitDeclContext(DeclContext *DC);
+  bool VisitTranslationUnitDecl(TranslationUnitDecl *D);
+  bool VisitTypedefDecl(TypedefDecl *D);
+  bool VisitTagDecl(TagDecl *D);
+  bool VisitClassTemplateSpecializationDecl(ClassTemplateSpecializationDecl *D);
+  bool VisitClassTemplatePartialSpecializationDecl(
+                                     ClassTemplatePartialSpecializationDecl *D);
+  bool VisitTemplateTypeParmDecl(TemplateTypeParmDecl *D);
+  bool VisitEnumConstantDecl(EnumConstantDecl *D);
+  bool VisitDeclaratorDecl(DeclaratorDecl *DD);
+  bool VisitFunctionDecl(FunctionDecl *ND);
+  bool VisitFieldDecl(FieldDecl *D);
+  bool VisitVarDecl(VarDecl *);
+  bool VisitNonTypeTemplateParmDecl(NonTypeTemplateParmDecl *D);
+  bool VisitFunctionTemplateDecl(FunctionTemplateDecl *D);
+  bool VisitClassTemplateDecl(ClassTemplateDecl *D);
+  bool VisitTemplateTemplateParmDecl(TemplateTemplateParmDecl *D);
+  bool VisitObjCTypeParamDecl(ObjCTypeParamDecl *D);
+  bool VisitObjCMethodDecl(ObjCMethodDecl *ND);
+  bool VisitObjCContainerDecl(ObjCContainerDecl *D);
+  bool VisitObjCCategoryDecl(ObjCCategoryDecl *ND);
+  bool VisitObjCProtocolDecl(ObjCProtocolDecl *PID);
+  bool VisitObjCPropertyDecl(ObjCPropertyDecl *PD);
+  bool VisitObjCTypeParamList(ObjCTypeParamList *typeParamList);
+  bool VisitObjCInterfaceDecl(ObjCInterfaceDecl *D);
+  bool VisitObjCImplDecl(ObjCImplDecl *D);
+  bool VisitObjCCategoryImplDecl(ObjCCategoryImplDecl *D);
+  bool VisitObjCImplementationDecl(ObjCImplementationDecl *D);
+  // FIXME: ObjCCompatibleAliasDecl requires aliased-class locations.
+  bool VisitObjCPropertyImplDecl(ObjCPropertyImplDecl *PD);
+  bool VisitLinkageSpecDecl(LinkageSpecDecl *D);
+  bool VisitNamespaceDecl(NamespaceDecl *D);
+  bool VisitNamespaceAliasDecl(NamespaceAliasDecl *D);
+  bool VisitUsingDirectiveDecl(UsingDirectiveDecl *D);
+  bool VisitUsingDecl(UsingDecl *D);
+  bool VisitUnresolvedUsingValueDecl(UnresolvedUsingValueDecl *D);
+  bool VisitUnresolvedUsingTypenameDecl(UnresolvedUsingTypenameDecl *D);
+  bool VisitStaticAssertDecl(StaticAssertDecl *D);
+  bool VisitFriendDecl(FriendDecl *D);
+
+  // Name visitor
+  bool VisitDeclarationNameInfo(DeclarationNameInfo Name);
+  bool VisitNestedNameSpecifier(NestedNameSpecifier *NNS, SourceRange Range);
+  bool VisitNestedNameSpecifierLoc(NestedNameSpecifierLoc NNS);
+
+  // Template visitors
+  bool VisitTemplateParameters(const TemplateParameterList *Params);
+  bool VisitTemplateName(TemplateName Name, SourceLocation Loc);
+  bool VisitTemplateArgumentLoc(const TemplateArgumentLoc &TAL);
+
+  // Type visitors
+#define ABSTRACT_TYPELOC(CLASS, PARENT)
+#define TYPELOC(CLASS, PARENT) \
+  bool Visit##CLASS##TypeLoc(CLASS##TypeLoc TyLoc);
+#include "clang/AST/TypeLocNodes.def"
+
+  bool VisitTagTypeLoc(TagTypeLoc TL);
+  bool VisitArrayTypeLoc(ArrayTypeLoc TL);
+  bool VisitFunctionTypeLoc(FunctionTypeLoc TL, bool SkipResultType = false);
+*/
 
 #endif // __NAMELINT_MY_AST_VISITOR__H__

--- a/source/test/sample/Sample01UpperCamel.c
+++ b/source/test/sample/Sample01UpperCamel.c
@@ -1,4 +1,4 @@
-﻿// [General.Rules]
+// [General.Rules]
 // FileName                = 1 # 1: UpperCamel
 // FunctionName            = 1 # 1: UpperCamel
 // VariableName            = 1 # 1: UpperCamel

--- a/source/test/sample/Sample01UpperCamel.toml
+++ b/source/test/sample/Sample01UpperCamel.toml
@@ -1,4 +1,4 @@
-﻿[General.Options]
+[General.Options]
 Version                 = 0.2
 FileExtNameList         = ["*.c","*.h","*.cpp"]
 CheckVariableName       = true

--- a/source/test/sample/Sample02_UpperCamel.c
+++ b/source/test/sample/Sample02_UpperCamel.c
@@ -1,4 +1,4 @@
-﻿// [General.Rules]
+// [General.Rules]
 // FileName                = 1 # 1: UpperCamel
 // FunctionName            = 1 # 1: UpperCamel
 // VariableName            = 1 # 1: UpperCamel

--- a/source/test/sample/Sample02_UpperCamel.toml
+++ b/source/test/sample/Sample02_UpperCamel.toml
@@ -1,4 +1,4 @@
-﻿[General.Options]
+[General.Options]
 Version                 = 0.2
 FileExtNameList         = ["*.c","*.h","*.cpp"]
 CheckVariableName       = true

--- a/source/test/sample/Sample06LowerCamel.cpp
+++ b/source/test/sample/Sample06LowerCamel.cpp
@@ -1,4 +1,4 @@
-﻿// [General.Rules]
+// [General.Rules]
 // FileName                = 1 # 1: UpperCamel
 // FunctionName            = 1 # 1: UpperCamel
 // variableName            = 4 # 4: Hungarian

--- a/source/test/sample/Sample07.cpp
+++ b/source/test/sample/Sample07.cpp
@@ -1,0 +1,20 @@
+﻿#include "Sample07.h"
+#include "Sample07a.h"
+
+#define min2(X, Y) ((X) < (Y) ? (X) : (Y))
+typedef void (*fnFunc)(short s, short);
+
+MyClass::MyClass() {}
+
+MyClass::~MyClass() {}
+
+bool MyClass::MyPubFunc(int) {
+  ITEM Item;
+  ITEM *pItem;
+  return true;
+}
+
+bool MyClass::MyPrivFunc(int Value) {
+  Value = min2(Value, 10);
+  return true;
+}

--- a/source/test/sample/Sample07.cpp
+++ b/source/test/sample/Sample07.cpp
@@ -1,4 +1,4 @@
-﻿#include "Sample07.h"
+#include "Sample07.h"
 #include "Sample07a.h"
 
 #define min2(X, Y) ((X) < (Y) ? (X) : (Y))

--- a/source/test/sample/Sample07.h
+++ b/source/test/sample/Sample07.h
@@ -1,0 +1,9 @@
+class MyClass {
+public:
+  MyClass();
+  ~MyClass();
+  bool MyPubFunc(int);
+
+private:
+  bool MyPrivFunc(int);
+};

--- a/source/test/sample/Sample07.toml
+++ b/source/test/sample/Sample07.toml
@@ -1,0 +1,155 @@
+[General.Options]
+Version                 = 0.2
+FileExtNameList         = ["*.c","*.h","*.cpp"]
+CheckVariableName       = true
+CheckFunctionName       = true
+CheckFileName           = false
+AllowedUnderscopeChar   = false
+AllowedArrayAffected    = false
+
+
+[General.Rules]
+FileName                = 0 # 0: Default (UpperCamel)
+                            # 1: UpperCamel
+                            # 3: lower_snake
+
+FunctionName            = 0 # 0: Default (UpperCamel)
+                            # 1: UpperCamel
+                            # 2: lowerCamel
+                            # 3: lower_snake
+
+VariableName            = 4 # 0: Default (UpperCamel)
+                            # 1: UpperCamel
+                            # 2: lowerCamel
+                            # 3: lower_snake
+                            # 4: Hungarian
+
+[General.IgnoredList]
+FunctionPrefix          = [ "_",
+                            "__" ]
+VariablePrefix          = [ "m_" ]
+
+FunctionName            = ["main", "newASTConsumer"]
+
+[Hungarian.Others]
+PreferUpperCamelIfMissed = true
+
+[Hungarian.NullStringList]
+"char*"                  = "sz"
+"wchar_t*"               = "wsz"
+"char**"                 = "psz"
+"wchar_t**"              = "pwsz"
+"char[]"                 = "sz"
+"wchar_t[]"              = "wsz"
+
+[Hungarian.WordList]
+# C Primitive Type
+"void"                   = ""
+"size_t"                 = "n"
+"int8_t"                 = "i8"
+"int16_t"                = "i16"
+"int32_t"                = "i32"
+"int64_t"                = "i64"
+"uint8_t"                = "u8"
+"uint16_t"               = "u16"
+"uint32_t"               = "u32"
+"uint64_t"               = "u64"
+"char"                   = "c"
+"_Bool"                  = "b"
+"bool"                   = "b"
+"int"                    = "i"
+"wchar_t"                = "wc"
+"signed char"            = "sc"
+"unsigned char"          = "uc"
+"short"                  = "s"
+"short int"              = "si"
+"signed short"           = "ss"
+"signed short int"       = "ssi"
+"unsigned short"         = "us"
+"unsigned short int"     = "usi"
+"signed"                 = "s"
+"signed int"             = "si"
+"unsigned"               = "u"
+"unsigned int"           = "ui"
+"long"                   = "l"
+"long int"               = "li"
+"signed long"            = "sl"
+"signed long int"        = "sli"
+"unsigned long"          = "ul"
+"unsigned long int"      = "uli"
+"long long"              = "ll"
+"long long int"          = "lli"
+"signed long long"       = "sll"
+"signed long long int"   = "slli"
+"unsigned long long"     = "ull"
+"unsigned long long int" = "ulli"
+"float"                  = "f"
+"double"                 = "d"
+"long double"            = "ld"
+
+# Windows Type - Variable
+"ULONG"                  = "ul"
+"UINT"                   = "ui"
+"DWORD"                  = "dw"
+"DWORD64"                = "dw64"
+"WORD"                   = "w"
+"CHAR"                   = "c"
+"BYTE"                   = "by"
+"BOOL"                   = "b"
+"BOOLEAN"                = "b"
+"LONGLONG"               = "ll"
+"UCHAR"                  = "uc"
+
+# Windows Type - Handle
+HANDLE                   = "h"
+HACCEL                   = "h"
+HBITMAP                  = "h"
+HBRUSH                   = "h"
+HCOLORSPACE              = "h"
+HCONV                    = "h"
+HCONVLIST                = "h"
+HCURSOR                  = "h"
+HDC                      = "h"
+HDDEDATA                 = "h"
+HDESK                    = "h"
+HDROP                    = "h"
+HDWP                     = "h"
+HENHMETAFILE             = "h"
+HFILE                    = "h"
+HFONT                    = "h"
+HGDIOBJ                  = "h"
+HGLOBAL                  = "h"
+HHOOK                    = "h"
+HICON                    = "h"
+HINSTANCE                = "h"
+HKEY                     = "h"
+HLOCAL                   = "h"
+HMENU                    = "h"
+HMETAFILE                = "h"
+HMODULE                  = "h"
+HMONITOR                 = "h"
+HPALETTE                 = "h"
+HPEN                     = "h"
+HRGN                     = "h"
+HRSRC                    = "h"
+HSZ                      = "h"
+HWINSTA                  = "h"
+HWND                     = "h"
+LPHANDLE                 = "h"
+PHANDLE                  = "h"
+SC_HANDLE                = "h"
+SERVICE_STATUS_HANDLE    = "h"
+
+# Windows Type - Parameter
+WPARAM                   = "w"
+LPARAM                   = "l"
+
+# Redefined pointer types
+# PINT8                  = "i8"   # PINT8  pi8Value  = NULL;
+# PINT16                 = "i16"  # PINT16 pi16Value = NULL;
+# PINT32                 = "i32"  # PINT32 pi32Value = NULL;
+# PINT64                 = "i64"  # PINT64 pi64Value = NULL;
+# PUINT8                 = "u8"   # PINT8  pu8Value  = NULL;
+# PUINT16                = "u16"  # PINT16 pu16Value = NULL;
+# PUINT32                = "u32"  # PINT32 pu32Value = NULL;
+# PUINT64                = "u64"  # PINT64 pu64Value = NULL;

--- a/source/test/sample/sample03_lower_snake.c
+++ b/source/test/sample/sample03_lower_snake.c
@@ -1,4 +1,4 @@
-﻿// [General.Rules]
+// [General.Rules]
 // FileName                = 1 # 1: UpperCamel
 // FunctionName            = 3 # 3: lower_snake
 // VariableName            = 3 # 3: lower_snake

--- a/source/test/sample/sample03_lower_snake.toml
+++ b/source/test/sample/sample03_lower_snake.toml
@@ -1,4 +1,4 @@
-﻿[General.Options]
+[General.Options]
 Version                 = 0.2
 FileExtNameList         = ["*.c","*.h","*.cpp"]
 CheckVariableName       = true

--- a/source/test/sample/sample04_lower_snake.cpp
+++ b/source/test/sample/sample04_lower_snake.cpp
@@ -1,4 +1,4 @@
-﻿// [General.Rules]
+// [General.Rules]
 // FileName                = 1 # 1: UpperCamel
 // FunctionName            = 3 # 3: lower_snake
 // VariableName            = 3 # 3: lower_snake

--- a/source/test/sample/sample05HungarianNotation.cpp
+++ b/source/test/sample/sample05HungarianNotation.cpp
@@ -1,4 +1,4 @@
-﻿// [General.Rules]
+// [General.Rules]
 // FileName                = 1 # 1: UpperCamel
 // FunctionName            = 1 # 1: UpperCamel
 // VariableName            = 4 # 4: Hungarian


### PR DESCRIPTION
Fixed issue that cppnamelint would not check header file.

Why:
It is essential feature.

HowToFix:
ClangTool parses header files with `-x c-header` option, use `-x c++` instead.