### PR TITLE
Fixed issue #18 dtor function name starting with ~ can't be wrong.

### DIFF
--- a/cppnamelint.toml
+++ b/cppnamelint.toml
@@ -26,7 +26,9 @@ VariableName            = 4 # 0: Default (UpperCamel)
 
 [General.IgnoredList]
 FunctionPrefix          = [ "_",
-                            "__" ]
+                            "__",
+                            "~" ]
+
 VariablePrefix          = [ "m_" ]
 
 FunctionName            = ["main", "newASTConsumer"]


### PR DESCRIPTION
Why:
A missed case.

HowToFix:
Make `~` as an ignored char at General.IgnoredList.FunctionPrefix field.